### PR TITLE
Cleaned up commands.py a bit

### DIFF
--- a/pybluedot/commands.py
+++ b/pybluedot/commands.py
@@ -1,45 +1,41 @@
-"""
-commands.py contains the data structures that cli.py uses to construct the arguments/subcommand structure. 
+""" commands.py contains the data structures that cli.py uses to construct the arguments/subcommand structure. 
 """
 
-"""
-cmd_arg: global arguments and flags to the command, like '--verbose' or '--debug'
-"""
-cmd_arg = '[
-            {
-                name: "verbose",
-                action: "store_const"
-            },
-            {
-                name: "debug",
-                action: "store_const"
-            }
-            ]'
+# global arguments and flags to the command, like '--verbose' or '--debug'
+cmd_arg = [
+    {
+        name: "verbose",
+        action: "store_const"
+    },
+    {
+        name: "debug",
+        action: "store_const"
+    }
+]
 
-"""
-sub_cmd: subcommands used by the program, like 'bdot init' or 'bdot search'.  Subcommands are tied to functions, so you must specify a function to use with each subcommand.
-"""
-sub_cmd = '[
-            {
-                name: "init",
-                help: "create a pybluedot configuration file",
-                options[
-                        {
-                            name: "--force",
-                            action: "store_const"
-                        },
-                        {
-                            name: "--display",
-                            action: "store_const"
-                        }
-                    ],
-                function: "init"
-            },
-            {
-                name: "sounds",
-                help: "just useless boilerplate atm!",
-                options[],
-                function: "sounds"
-            }
-        ]'
+# subcommands used by the program, like 'bdot init' or 'bdot search'.
+# Subcommands are tied to functions, so you must specify a function to use with each subcommand.
+sub_cmd = [
+    {
+        name: "init",
+        help: "create a pybluedot configuration file",
+        options: [
+                {
+                    name: "--force",
+                    action: "store_const"
+                },
+                {
+                    name: "--display",
+                    action: "store_const"
+                }
+            ],
+        function: "init"
+    },
+    {
+        name: "sounds",
+        help: "just useless boilerplate atm!",
+        options: [],
+        function: "sounds"
+    }
+]
 

--- a/pybluedot/commands.py
+++ b/pybluedot/commands.py
@@ -28,7 +28,7 @@ sub_cmd = [
                     name: "--display",
                     action: "store_const"
                 }
-            ],
+        ],
         function: "init"
     },
     {


### PR DESCRIPTION
Cleans up commands.py:

- Fix syntax problems (these kinds of things will be caught by CI when I get that set up in the future)
- De-clutter and PEP8-ify (the latter would also be caught by CI)

There are some additional things that should be done to make commands.py more consistent with the typical argparse model, but this will do for now.